### PR TITLE
Add raw AES-GCM key to document head instead of Keyset

### DIFF
--- a/golang/pkg/encryption/encryption.go
+++ b/golang/pkg/encryption/encryption.go
@@ -19,6 +19,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"github.com/golang/protobuf/proto"
 	"github.com/google/tink/go/aead"
@@ -224,8 +225,8 @@ func encryptAllSections(parsedHTML *html.Node, encryptedSections []*html.Node, k
 }
 
 type swgEncryptionKey struct {
-	accessRequirement []string
-	key               string
+	AccessRequirement []string
+	Key               string
 }
 
 // Encrypts the document's symmetric key using the input Keyset.
@@ -241,18 +242,20 @@ func encryptDocumentKey(docKeyset, accessRequirement string, pubKeys map[string]
 			return nil, err
 		}
 		swgKey := swgEncryptionKey{
-			accessRequirement: []string{accessRequirement},
-			key:               docKeyset,
+			AccessRequirement: []string{accessRequirement},
+			Key:               docKeyset,
 		}
-		log.Println("doc keyset: ", docKeyset)
+		log.Println("swgkey: ", fmt.Sprintf("%v", swgKey))
 		jsonData, err := json.Marshal(swgKey)
 		if err != nil {
 			return nil, err
 		}
+		log.Println("jsondata: ", base64.StdEncoding.EncodeToString(jsonData))
 		enc, err := he.Encrypt(jsonData, nil)
 		if err != nil {
 			return nil, err
 		}
+		log.Println("out: ", base64.StdEncoding.EncodeToString(enc))
 		outMap[domain] = base64.StdEncoding.EncodeToString(enc)
 	}
 	return outMap, nil

--- a/golang/pkg/encryption/encryption.go
+++ b/golang/pkg/encryption/encryption.go
@@ -19,6 +19,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"log"
 	"github.com/golang/protobuf/proto"
 	"github.com/google/tink/go/aead"
 	"github.com/google/tink/go/core/registry"
@@ -49,11 +50,11 @@ func GenerateEncryptedDocument(htmlStr, accessRequirement string, pubKeys map[st
 	if err != nil {
 		return "", err
 	}
-	ks := createAesGcmKeyset(key)
-	ksEnc, err := proto.Marshal(&ks)
+	keyBuf, err := proto.Marshal(key)
 	if err != nil {
 		return "", err
 	}
+	ks := createAesGcmKeyset(keyBuf)
 	kh, err := insecurecleartextkeyset.Read(&keyset.MemReaderWriter{Keyset: &ks})
 	if err != nil {
 		return "", err
@@ -69,7 +70,7 @@ func GenerateEncryptedDocument(htmlStr, accessRequirement string, pubKeys map[st
 	if err = encryptAllSections(parsedHTML, encryptedSections, kh); err != nil {
 		return "", err
 	}
-	encryptedKeys, err := encryptDocumentKey(base64.StdEncoding.EncodeToString(ksEnc), accessRequirement, pubKeys)
+	encryptedKeys, err := encryptDocumentKey(base64.StdEncoding.EncodeToString(key.KeyValue), accessRequirement, pubKeys)
 	if err != nil {
 		return "", err
 	}
@@ -94,7 +95,7 @@ func RetrieveTinkPublicKey(publicKeyURL string) (tinkpb.Keyset, error) {
 }
 
 // Generates a new AES-GCM key.
-func generateNewAesGcmKey(km registry.KeyManager) ([]byte, error) {
+func generateNewAesGcmKey(km registry.KeyManager) (*gcmpb.AesGcmKey, error) {
 	p, err := proto.Marshal(&gcmpb.AesGcmKeyFormat{KeySize: aesGCMKeySize})
 	if err != nil {
 		return nil, err
@@ -103,7 +104,7 @@ func generateNewAesGcmKey(km registry.KeyManager) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return proto.Marshal(m)
+	return m.(*gcmpb.AesGcmKey), nil
 }
 
 // Creates an AES-GCM Keyset using the input key.
@@ -130,7 +131,7 @@ func createAesGcmKeyset(key []byte) tinkpb.Keyset {
 			KeyData:          &keyData,
 			Status:           tinkpb.KeyStatusType_ENABLED,
 			KeyId:            1,
-			OutputPrefixType: tinkpb.OutputPrefixType_TINK,
+			OutputPrefixType: tinkpb.OutputPrefixType_RAW,
 		},
 	}
 	return tinkpb.Keyset{
@@ -243,6 +244,7 @@ func encryptDocumentKey(docKeyset, accessRequirement string, pubKeys map[string]
 			accessRequirement: []string{accessRequirement},
 			key:               docKeyset,
 		}
+		log.Println("doc keyset: ", docKeyset)
 		jsonData, err := json.Marshal(swgKey)
 		if err != nil {
 			return nil, err

--- a/golang/pkg/encryption/encryption.go
+++ b/golang/pkg/encryption/encryption.go
@@ -19,8 +19,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"fmt"
-	"log"
 	"github.com/golang/protobuf/proto"
 	"github.com/google/tink/go/aead"
 	"github.com/google/tink/go/core/registry"
@@ -230,7 +228,7 @@ type swgEncryptionKey struct {
 }
 
 // Encrypts the document's symmetric key using the input Keyset.
-func encryptDocumentKey(docKeyset, accessRequirement string, pubKeys map[string]tinkpb.Keyset) (map[string]string, error) {
+func encryptDocumentKey(docKey, accessRequirement string, pubKeys map[string]tinkpb.Keyset) (map[string]string, error) {
 	outMap := make(map[string]string)
 	for domain, ks := range pubKeys {
 		handle, err := keyset.NewHandleWithNoSecrets(&ks)
@@ -243,19 +241,16 @@ func encryptDocumentKey(docKeyset, accessRequirement string, pubKeys map[string]
 		}
 		swgKey := swgEncryptionKey{
 			AccessRequirement: []string{accessRequirement},
-			Key:               docKeyset,
+			Key:               docKey,
 		}
-		log.Println("swgkey: ", fmt.Sprintf("%v", swgKey))
 		jsonData, err := json.Marshal(swgKey)
 		if err != nil {
 			return nil, err
 		}
-		log.Println("jsondata: ", base64.StdEncoding.EncodeToString(jsonData))
 		enc, err := he.Encrypt(jsonData, nil)
 		if err != nil {
 			return nil, err
 		}
-		log.Println("out: ", base64.StdEncoding.EncodeToString(enc))
 		outMap[domain] = base64.StdEncoding.EncodeToString(enc)
 	}
 	return outMap, nil

--- a/golang/pkg/encryption/encryption.go
+++ b/golang/pkg/encryption/encryption.go
@@ -69,7 +69,7 @@ func GenerateEncryptedDocument(htmlStr, accessRequirement string, pubKeys map[st
 	if err = encryptAllSections(parsedHTML, encryptedSections, kh); err != nil {
 		return "", err
 	}
-	encryptedKeys, err := encryptDocumentKey(base64.StdEncoding.EncodeToString(key.KeyValue), accessRequirement, pubKeys)
+	encryptedKeys, err := encryptDocumentKey(key.KeyValue, accessRequirement, pubKeys)
 	if err != nil {
 		return "", err
 	}
@@ -228,7 +228,7 @@ type swgEncryptionKey struct {
 }
 
 // Encrypts the document's symmetric key using the input Keyset.
-func encryptDocumentKey(docKey, accessRequirement string, pubKeys map[string]tinkpb.Keyset) (map[string]string, error) {
+func encryptDocumentKey(docKey []byte, accessRequirement string, pubKeys map[string]tinkpb.Keyset) (map[string]string, error) {
 	outMap := make(map[string]string)
 	for domain, ks := range pubKeys {
 		handle, err := keyset.NewHandleWithNoSecrets(&ks)
@@ -241,7 +241,7 @@ func encryptDocumentKey(docKey, accessRequirement string, pubKeys map[string]tin
 		}
 		swgKey := swgEncryptionKey{
 			AccessRequirement: []string{accessRequirement},
-			Key:               docKey,
+			Key:               base64.StdEncoding.EncodeToString(docKey),
 		}
 		jsonData, err := json.Marshal(swgKey)
 		if err != nil {


### PR DESCRIPTION
Modifies the key stored in the cryptokeys script in head to go from sending an entire Keyset vs. just the raw symmetric key. This makes it so we can use different cryptographic packages to encrypt/decrypt.

Changes the prefix type of the encrypted messages from "TINK" to "RAW", meaning that no extra information about the keys gets appended to the encrypted text: https://github.com/google/tink/blob/master/proto/tink.proto#L70

Capitalizes names in JSON object so that golang exports them correctly.