### PR TITLE
Add check for isIE before accessing self.crypto

### DIFF
--- a/js/aes_gcm.js
+++ b/js/aes_gcm.js
@@ -24,7 +24,7 @@
 export function decryptAesGcm(key, text) {
   const keybytes = base64Decode(key);
   const isIE = !!self.msCrypto;
-  const subtle = (self.crypto || self.msCrypto).subtle;
+  const subtle = isIE ? self.msCrypto.subtle : self.crypto.subtle;
   return wrapCryptoOp(subtle.importKey('raw', keybytes.buffer,
     'AES-GCM',
     true, ['decrypt'])).


### PR DESCRIPTION
IE is throwing an error that "crypto" is not found. This code checks to see if we are on IE before accessing self.crypto.