### PR TITLE
Add golang/vendor/github.com/google/tink/go/integration/* to vendor

### DIFF
--- a/golang/cmd/gcp_key_gen/README.md
+++ b/golang/cmd/gcp_key_gen/README.md
@@ -10,6 +10,7 @@ This script was inspired by the Medium post [Google Cloud KMS & Tink](https://me
 ```shell
 # Go get the script
 go get -u github.com/subscriptions-project/encryption/golang/cmd/gcp_key_gen
+```
 
 ## Example Usage:
 

--- a/golang/vendor/github.com/google/tink/go/integration/awskms/BUILD.bazel
+++ b/golang/vendor/github.com/google/tink/go/integration/awskms/BUILD.bazel
@@ -1,0 +1,45 @@
+package(default_visibility = ["//tools/build_defs:internal_pkg"])
+
+licenses(["notice"])  # keep
+
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "aws_kms_aead.go",
+        "aws_kms_client.go",
+    ],
+    importpath = "github.com/google/tink/go/integration/awskms",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_aws_sdk_go//aws:go_default_library",
+        "@com_github_aws_sdk_go//service/kms:go_default_library",
+        "@com_github_aws_sdk_go//aws/credentials:go_default_library",
+        "@com_github_aws_sdk_go//aws/session:go_default_library",
+        "//go/aead:go_default_library",
+        "//go/tink:go_default_library",
+        "//go/core/registry:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["aws_kms_aead_test.go"],
+    data = [
+        "@google_root_pem//file", #keep
+        "//testdata:credentials",
+    ],
+    embed = [":go_default_library",],
+    deps = [
+        "//go/aead:go_default_library",
+        "//go/subtle/random:go_default_library",
+        "//go/subtle/aead:go_default_library",
+        "//go/tink:go_default_library",
+        "//go/keyset:go_default_library",
+        "//go/core/registry:go_default_library",
+    ],
+    tags = ["no_rbe"],
+)

--- a/golang/vendor/github.com/google/tink/go/integration/awskms/aws_kms_aead.go
+++ b/golang/vendor/github.com/google/tink/go/integration/awskms/aws_kms_aead.go
@@ -1,0 +1,93 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+// Package awskms provides integration with the AWS Cloud KMS.
+package awskms
+
+import (
+	"encoding/hex"
+	"errors"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/kms"
+
+	"github.com/google/tink/go/aead"
+	"github.com/google/tink/go/tink"
+)
+
+// AWSAEAD represents a AWS KMS service to a particular URI.
+type AWSAEAD struct {
+	keyURI string
+	kms    *kms.KMS
+}
+
+var (
+	_       tink.AEAD = (*AWSAEAD)(nil)
+	awsaead           = aead.New
+)
+
+// NewAWSAEAD returns a new AWS KMS service.
+func NewAWSAEAD(keyURI string, kms *kms.KMS) *AWSAEAD {
+	return &AWSAEAD{
+		keyURI: keyURI,
+		kms:    kms,
+	}
+}
+
+// Encrypt AEAD encrypts the plaintext data and uses addtionaldata from authentication.
+func (a *AWSAEAD) Encrypt(plaintext, additionalData []byte) ([]byte, error) {
+	ad := hex.EncodeToString(additionalData)
+	req := &kms.EncryptInput{
+		KeyId:             aws.String(a.keyURI),
+		Plaintext:         plaintext,
+		EncryptionContext: map[string]*string{"additionalData": &ad},
+	}
+	if ad == "" {
+		req = &kms.EncryptInput{
+			KeyId:     aws.String(a.keyURI),
+			Plaintext: plaintext,
+		}
+	}
+	resp, err := a.kms.Encrypt(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.CiphertextBlob, nil
+}
+
+// Decrypt AEAD decrypts the data and verified the additional data.
+func (a *AWSAEAD) Decrypt(ciphertext, additionalData []byte) ([]byte, error) {
+	ad := hex.EncodeToString(additionalData)
+	req := &kms.DecryptInput{
+		CiphertextBlob:    ciphertext,
+		EncryptionContext: map[string]*string{"additionalData": &ad},
+	}
+	if ad == "" {
+		req = &kms.DecryptInput{
+			CiphertextBlob: ciphertext,
+		}
+	}
+	resp, err := a.kms.Decrypt(req)
+	if strings.Compare(*resp.KeyId, a.keyURI) != 0 {
+		return nil, errors.New("decryption failed: wrong key id")
+	}
+	if err != nil {
+		return nil, err
+	}
+	return resp.Plaintext, nil
+}

--- a/golang/vendor/github.com/google/tink/go/integration/awskms/aws_kms_aead_test.go
+++ b/golang/vendor/github.com/google/tink/go/integration/awskms/aws_kms_aead_test.go
@@ -1,0 +1,134 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package awskms
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	// ignore-placeholder1
+	// ignore-placeholder2
+	"testing"
+
+	"flag"
+	// context is used to cancel outstanding requests
+	// TEST_SRCDIR to read the roots.pem
+	"github.com/google/tink/go/aead"
+	"github.com/google/tink/go/core/registry"
+	"github.com/google/tink/go/keyset"
+	// ignore-placeholder3
+	"github.com/google/tink/go/subtle/random"
+	"github.com/google/tink/go/tink"
+)
+
+const (
+	keyURI  = "aws-kms://arn:aws:kms:us-east-2:235739564943:key/3ee50705-5a82-4f5b-9753-05c4f473922f"
+	profile = "tink-user1"
+)
+
+var (
+	// lint placeholder header, please ignore
+	credFile = os.Getenv("TEST_SRCDIR") + "/" + os.Getenv("TEST_WORKSPACE") + "/" + "testdata/credentials_aws.csv"
+	// lint placeholder footer, please ignore
+)
+
+// lint placeholder header, please ignore
+func init() {
+	certPath := os.Getenv("TEST_SRCDIR") + "/" + os.Getenv("TEST_WORKSPACE") + "/" + "roots.pem"
+	flag.Set("cacerts", certPath)
+	os.Setenv("SSL_CERT_FILE", certPath)
+}
+
+// lint placeholder footer, please ignore
+
+func setupKMS(t *testing.T) {
+	t.Helper()
+	g, err := NewAWSClient(keyURI)
+	if err != nil {
+		t.Fatalf("error setting up aws client: %v", err)
+	}
+	_, err = g.LoadCredentials(credFile)
+	if err != nil {
+		t.Fatalf("error loading credentials : %v", err)
+	}
+	registry.RegisterKMSClient(g)
+}
+
+func basicAEADTest(t *testing.T, a tink.AEAD) error {
+	t.Helper()
+	for i := 0; i < 100; i++ {
+		pt := random.GetRandomBytes(20)
+		ad := random.GetRandomBytes(20)
+		ct, err := a.Encrypt(pt, ad)
+		if err != nil {
+			return err
+		}
+		dt, err := a.Decrypt(ct, ad)
+		if err != nil {
+			return err
+		}
+		if !bytes.Equal(dt, pt) {
+			return errors.New("decrypt not inverse of encrypt")
+		}
+	}
+	return nil
+}
+
+func TestBasicAead(t *testing.T) {
+	setupKMS(t)
+	// ignore-placeholder4
+	dek := aead.AES128CTRHMACSHA256KeyTemplate()
+	kh, err := keyset.NewHandle(aead.KMSEnvelopeAEADKeyTemplate(keyURI, dek))
+	if err != nil {
+		t.Fatalf("error getting a new keyset handle: %v", err)
+	}
+	a, err := awsaead(kh)
+	if err != nil {
+		t.Fatalf("error getting the primitive: %v", err)
+	}
+	if err := basicAEADTest(t, a); err != nil {
+		t.Errorf("error in basic aead tests: %v", err)
+	}
+}
+
+func TestBasicAeadWithoutAdditionalData(t *testing.T) {
+	setupKMS(t)
+	// ignore-placeholder4
+	dek := aead.AES128CTRHMACSHA256KeyTemplate()
+	kh, err := keyset.NewHandle(aead.KMSEnvelopeAEADKeyTemplate(keyURI, dek))
+	if err != nil {
+		t.Fatalf("error getting a new keyset handle: %v", err)
+	}
+	a, err := awsaead(kh)
+	if err != nil {
+		t.Fatalf("error getting the primitive: %v", err)
+	}
+	for i := 0; i < 100; i++ {
+		pt := random.GetRandomBytes(20)
+		ct, err := a.Encrypt(pt, nil)
+		if err != nil {
+			t.Fatalf("error encrypting data: %v", err)
+		}
+		dt, err := a.Decrypt(ct, nil)
+		if err != nil {
+			t.Fatalf("error decrypting data: %v", err)
+		}
+		if !bytes.Equal(dt, pt) {
+			t.Fatalf("decrypt not inverse of encrypt")
+		}
+	}
+}
+
+// ignore-placeholder5

--- a/golang/vendor/github.com/google/tink/go/integration/awskms/aws_kms_client.go
+++ b/golang/vendor/github.com/google/tink/go/integration/awskms/aws_kms_client.go
@@ -1,0 +1,174 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package awskms
+
+import (
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/google/tink/go/core/registry"
+	"github.com/google/tink/go/tink"
+)
+
+const (
+	awsPrefix = "aws-kms://"
+)
+
+var (
+	errCred = errors.New("invalid credential path")
+)
+
+// AWSClient represents a client that connects to the AWS KMS backend.
+type AWSClient struct {
+	keyURI string
+	kms    *kms.KMS
+	region string
+}
+
+var _ registry.KMSClient = (*AWSClient)(nil)
+
+// NewAWSClient returns a new client to AWS KMS. It does not have an established session.
+func NewAWSClient(URI string) (*AWSClient, error) {
+	if !strings.HasPrefix(strings.ToLower(URI), awsPrefix) {
+		return nil, fmt.Errorf("key URI must start with %s", awsPrefix)
+	}
+	r, err := getRegion(URI)
+	if err != nil {
+		return nil, err
+	}
+	return &AWSClient{
+		keyURI: URI,
+		region: r,
+	}, nil
+
+}
+
+// Supported true if this client does support keyURI
+func (g *AWSClient) Supported(keyURI string) bool {
+	if (len(g.keyURI) > 0) && (strings.Compare(strings.ToLower(g.keyURI), strings.ToLower(keyURI)) == 0) {
+		return true
+	}
+	return ((len(g.keyURI) == 0) && (strings.HasPrefix(strings.ToLower(keyURI), awsPrefix)))
+}
+
+// LoadCredentials loads the credentials in credentialPath. If credentialPath is  null, loads the
+// default credentials.
+func (g *AWSClient) LoadCredentials(credentialPath string) (*AWSClient, error) {
+	var creds *credentials.Credentials
+	if len(credentialPath) <= 0 {
+		return nil, errCred
+	}
+	c, err := extractCredsCSV(credentialPath)
+	if err != nil {
+		creds = credentials.NewSharedCredentials(credentialPath, "default")
+	} else {
+		creds = credentials.NewStaticCredentialsFromCreds(*c)
+	}
+	session := session.Must(session.NewSession(&aws.Config{
+		Credentials: creds,
+		Region:      aws.String(g.region),
+	}))
+
+	g.kms = kms.New(session)
+	return g, nil
+}
+
+// LoadDefaultCredentials loads with the default credentials.
+func (g *AWSClient) LoadDefaultCredentials() (*AWSClient, error) {
+	session := session.Must(session.NewSession(&aws.Config{
+		Region: aws.String(g.region),
+	}))
+	g.kms = kms.New(session)
+	return g, nil
+}
+
+// WithCredentials retrieves credentials using a provider.
+func (g *AWSClient) WithCredentials(p *credentials.Credentials) (*AWSClient, error) {
+	session := session.Must(session.NewSession(&aws.Config{
+		Region:      aws.String(g.region),
+		Credentials: p,
+	}))
+	g.kms = kms.New(session)
+	return g, nil
+}
+
+// GetAEAD gets an AEAD backend by keyURI.
+func (g *AWSClient) GetAEAD(keyURI string) (tink.AEAD, error) {
+	if len(g.keyURI) > 0 && strings.Compare(strings.ToLower(g.keyURI), strings.ToLower(keyURI)) != 0 {
+		return nil, fmt.Errorf("this client is bound to %s, cannot load keys bound to %s", g.keyURI, keyURI)
+	}
+	uri, err := validateTrimKMSPrefix(g.keyURI, awsPrefix)
+	if err != nil {
+		return nil, err
+	}
+	return NewAWSAEAD(uri, g.kms), nil
+}
+
+func validateKMSPrefix(keyURI, prefix string) bool {
+	if len(keyURI) > 0 && strings.HasPrefix(strings.ToLower(keyURI), awsPrefix) {
+		return true
+	}
+	return false
+}
+
+func validateTrimKMSPrefix(keyURI, prefix string) (string, error) {
+	if !validateKMSPrefix(keyURI, prefix) {
+		return "", fmt.Errorf("key URI must start with %s", prefix)
+	}
+	return strings.TrimPrefix(keyURI, prefix), nil
+}
+
+func extractCredsCSV(file string) (*credentials.Value, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	lines, err := csv.NewReader(f).ReadAll()
+	if err != nil {
+		return nil, err
+	}
+	if len(lines) < 2 {
+		return nil, errors.New("invalid csv file")
+	}
+	return &credentials.Value{
+		AccessKeyID:     lines[1][2],
+		SecretAccessKey: lines[1][3],
+	}, nil
+
+}
+
+func getRegion(keyURI string) (string, error) {
+	re1, err := regexp.Compile(`aws-kms://arn:aws:kms:([a-z0-9-]+):`)
+	if err != nil {
+		return "", err
+	}
+	r := re1.FindStringSubmatch(keyURI)
+	if len(r) != 2 {
+		return "", errors.New("extracting region from URI failed")
+	}
+	return r[1], nil
+}

--- a/golang/vendor/github.com/google/tink/go/integration/gcpkms/BUILD.bazel
+++ b/golang/vendor/github.com/google/tink/go/integration/gcpkms/BUILD.bazel
@@ -1,0 +1,42 @@
+package(default_visibility = ["//tools/build_defs:internal_pkg"])
+
+licenses(["notice"])  # keep
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "gcp_kms_aead.go",
+        "gcp_kms_client.go",
+    ],
+    importpath = "github.com/google/tink/go/integration/gcpkms",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//go/core/registry:go_default_library",
+        "//go/tink:go_default_library",
+        "@org_golang_google_api//cloudkms/v1:go_default_library",
+        "@org_golang_x_oauth2//:go_default_library",
+        "@org_golang_x_oauth2//google:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["gcp_kms_aead_test.go"],
+    data = [
+        "//testdata:credentials",
+        "//testdata:ecies_keysets",
+        "@google_root_pem//file",  #keep
+        "@wycheproof//testvectors:all",  #keep
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//go/aead:go_default_library",
+        "//go/core/registry:go_default_library",
+        "//go/keyset:go_default_library",
+        "//go/subtle/random:go_default_library",
+        "//go/tink:go_default_library",
+    ],
+    tags = ["no_rbe"],
+)

--- a/golang/vendor/github.com/google/tink/go/integration/gcpkms/gcp_kms_aead.go
+++ b/golang/vendor/github.com/google/tink/go/integration/gcpkms/gcp_kms_aead.go
@@ -1,0 +1,71 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+// Package gcpkms provides integration with the Google Cloud KMS.
+package gcpkms
+
+import (
+	"encoding/base64"
+
+	"google.golang.org/api/cloudkms/v1"
+
+	"github.com/google/tink/go/tink"
+)
+
+// GCPAEAD represents a GCP KMS service to a particular URI.
+type GCPAEAD struct {
+	keyURI string
+	kms    cloudkms.Service
+}
+
+var _ tink.AEAD = (*GCPAEAD)(nil)
+
+// NewGCPAEAD returns a new GCP KMS service.
+func NewGCPAEAD(keyURI string, kms *cloudkms.Service) *GCPAEAD {
+	return &GCPAEAD{
+		keyURI: keyURI,
+		kms:    *kms,
+	}
+}
+
+// Encrypt AEAD encrypts the plaintext data and uses addtionaldata from authentication.
+func (a *GCPAEAD) Encrypt(plaintext, additionalData []byte) ([]byte, error) {
+
+	req := &cloudkms.EncryptRequest{
+		Plaintext:                   base64.URLEncoding.EncodeToString(plaintext),
+		AdditionalAuthenticatedData: base64.URLEncoding.EncodeToString(additionalData),
+	}
+	resp, err := a.kms.Projects.Locations.KeyRings.CryptoKeys.Encrypt(a.keyURI, req).Do()
+	if err != nil {
+		return nil, err
+	}
+
+	return base64.StdEncoding.DecodeString(resp.Ciphertext)
+}
+
+// Decrypt AEAD decrypts the data and verified the additional data.
+func (a *GCPAEAD) Decrypt(ciphertext, additionalData []byte) ([]byte, error) {
+
+	req := &cloudkms.DecryptRequest{
+		Ciphertext:                  base64.URLEncoding.EncodeToString(ciphertext),
+		AdditionalAuthenticatedData: base64.URLEncoding.EncodeToString(additionalData),
+	}
+	resp, err := a.kms.Projects.Locations.KeyRings.CryptoKeys.Decrypt(a.keyURI, req).Do()
+	if err != nil {
+		return nil, err
+	}
+	return base64.StdEncoding.DecodeString(resp.Plaintext)
+}

--- a/golang/vendor/github.com/google/tink/go/integration/gcpkms/gcp_kms_aead_test.go
+++ b/golang/vendor/github.com/google/tink/go/integration/gcpkms/gcp_kms_aead_test.go
@@ -1,0 +1,97 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package gcpkms
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"testing"
+
+	"flag"
+	// context is used to cancel outstanding requests
+	// TEST_SRCDIR to read the roots.pem
+	"github.com/google/tink/go/aead"
+	"github.com/google/tink/go/core/registry"
+	"github.com/google/tink/go/keyset"
+	"github.com/google/tink/go/subtle/random"
+	"github.com/google/tink/go/tink"
+)
+
+const (
+	keyURI = "gcp-kms://projects/tink-test-infrastructure/locations/global/keyRings/unit-and-integration-testing/cryptoKeys/aead-key"
+)
+
+var (
+	// lint placeholder header, please ignore
+	credFile = os.Getenv("TEST_SRCDIR") + "/" + os.Getenv("TEST_WORKSPACE") + "/" + "testdata/credential.json"
+	// lint placeholder footer, please ignore
+)
+
+// lint placeholder header, please ignore
+func init() {
+	certPath := os.Getenv("TEST_SRCDIR") + "/" + os.Getenv("TEST_WORKSPACE") + "/" + "roots.pem"
+	flag.Set("cacerts", certPath)
+	os.Setenv("SSL_CERT_FILE", certPath)
+}
+
+// lint placeholder footer, please ignore
+
+func setupKMS(t *testing.T) {
+	t.Helper()
+	g, err := NewGCPClient(keyURI)
+	if err != nil {
+		t.Errorf("error setting up gcp client: %v", err)
+	}
+	if _, err = g.LoadCredentials(credFile); err != nil {
+		t.Fatalf("error loading credentials : %v", err)
+	}
+	registry.RegisterKMSClient(g)
+}
+
+func basicAEADTest(t *testing.T, a tink.AEAD) error {
+	t.Helper()
+	for i := 0; i < 100; i++ {
+		pt := random.GetRandomBytes(20)
+		ad := random.GetRandomBytes(20)
+		ct, err := a.Encrypt(pt, ad)
+		if err != nil {
+			return err
+		}
+		dt, err := a.Decrypt(ct, ad)
+		if err != nil {
+			return err
+		}
+		if !bytes.Equal(dt, pt) {
+			return errors.New("decrypt not inverse of encrypt")
+		}
+	}
+	return nil
+}
+func TestBasicAead(t *testing.T) {
+	setupKMS(t)
+	dek := aead.AES128CTRHMACSHA256KeyTemplate()
+	kh, err := keyset.NewHandle(aead.KMSEnvelopeAEADKeyTemplate(keyURI, dek))
+	if err != nil {
+		t.Errorf("error getting a new keyset handle: %v", err)
+	}
+	a, err := aead.New(kh)
+	if err != nil {
+		t.Errorf("error getting the primitive: %v", err)
+	}
+	if err := basicAEADTest(t, a); err != nil {
+		t.Errorf("error in basic aead tests: %v", err)
+	}
+}

--- a/golang/vendor/github.com/google/tink/go/integration/gcpkms/gcp_kms_client.go
+++ b/golang/vendor/github.com/google/tink/go/integration/gcpkms/gcp_kms_client.go
@@ -1,0 +1,179 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+// Package gcpkms provides integration with the GCP Cloud KMS.
+// Tink APIs work with GCP and AWS KMS.
+// GCP Example below:
+//
+// package main
+//
+// import (
+//     "github.com/google/tink/go/aead"
+//     "github.com/google/tink/go/core/registry"
+//     "github.com/google/tink/go/integration/gcpkms"
+//     "github.com/google/tink/go/keyset"
+// )
+//
+// const (
+//     keyURI = "gcp-kms://......"
+// )
+//
+// func main() {
+//     gcpclient := gcpkms.NewGCPClient(keyURI)
+//     _, err := gcpclient.LoadCredentials("/mysecurestorage/credentials.json")
+//     if err != nil {
+//         //handle error
+//     }
+//     registry.RegisterKMSClient(gcpclient)
+//
+//     dek := aead.AES128CTRHMACSHA256KeyTemplate()
+//     kh, err := keyset.NewHandle(aead.KMSEnvelopeAEADKeyTemplate(keyURI, dek))
+//     if err != nil {
+//         // handle error
+//     }
+//     a, err := aead.New(kh)
+//     if err != nil {
+//         // handle error
+//     }
+//
+//     ct, err = a.Encrypt([]byte("secret message"), []byte("associated data"))
+//     if err != nil {
+//         // handle error
+//     }
+//
+//     pt, err = a.Decrypt(ct, []byte("associated data"))
+//     if err != nil {
+//         // handle error
+//     }
+// }
+
+package gcpkms
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/google/tink/go/core/registry"
+	"github.com/google/tink/go/tink"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/cloudkms/v1"
+)
+
+const (
+	gcpPrefix = "gcp-kms://"
+)
+
+var (
+	errCred = errors.New("invalid credential path")
+)
+
+// GCPClient represents a client that connects to the GCP KMS backend.
+type GCPClient struct {
+	keyURI string
+	kms    *cloudkms.Service
+}
+
+var _ registry.KMSClient = (*GCPClient)(nil)
+
+// NewGCPClient returns a new client to GCP KMS. It does not have an established session.
+func NewGCPClient(URI string) (*GCPClient, error) {
+	if !strings.HasPrefix(strings.ToLower(URI), gcpPrefix) {
+		return nil, fmt.Errorf("key URI must start with %s", gcpPrefix)
+	}
+
+	return &GCPClient{
+		keyURI: URI,
+	}, nil
+
+}
+
+// Supported true if this client does support keyURI
+func (g *GCPClient) Supported(keyURI string) bool {
+	if (len(g.keyURI) > 0) && (strings.Compare(strings.ToLower(g.keyURI), strings.ToLower(keyURI)) == 0) {
+		return true
+	}
+	return ((len(g.keyURI) == 0) && (strings.HasPrefix(strings.ToLower(keyURI), gcpPrefix)))
+}
+
+// LoadCredentials loads the credentials in credentialPath. If credentialPath is  null, loads the
+// default credentials.
+func (g *GCPClient) LoadCredentials(credentialPath string) (*GCPClient, error) {
+	ctx := context.Background()
+	if len(credentialPath) <= 0 {
+		return nil, errCred
+	}
+	data, err := ioutil.ReadFile(credentialPath)
+	if err != nil {
+		return nil, errCred
+	}
+	creds, err := google.CredentialsFromJSON(ctx, data, "https://www.googleapis.com/auth/cloudkms")
+	if err != nil {
+		return nil, errCred
+	}
+	client := oauth2.NewClient(ctx, creds.TokenSource)
+	kmsService, err := cloudkms.New(client)
+	if err != nil {
+		return nil, err
+	}
+	g.kms = kmsService
+	return g, nil
+}
+
+// LoadDefaultCredentials loads with the default credentials.
+func (g *GCPClient) LoadDefaultCredentials() (*GCPClient, error) {
+	ctx := context.Background()
+	client, err := google.DefaultClient(ctx, cloudkms.CloudPlatformScope)
+	if err != nil {
+		return nil, err
+	}
+
+	kmsService, err := cloudkms.New(client)
+	if err != nil {
+		return nil, err
+	}
+	g.kms = kmsService
+	return g, nil
+}
+
+// GetAEAD gets an AEAD backend by keyURI.
+func (g *GCPClient) GetAEAD(keyURI string) (tink.AEAD, error) {
+	if len(g.keyURI) > 0 && strings.Compare(strings.ToLower(g.keyURI), strings.ToLower(keyURI)) != 0 {
+		return nil, fmt.Errorf("this client is bound to %s, cannot load keys bound to %s", g.keyURI, keyURI)
+	}
+	uri, err := validateTrimKMSPrefix(g.keyURI, gcpPrefix)
+	if err != nil {
+		return nil, err
+	}
+	return NewGCPAEAD(uri, g.kms), nil
+}
+
+func validateKMSPrefix(keyURI, prefix string) bool {
+	if len(keyURI) > 0 && strings.HasPrefix(strings.ToLower(keyURI), gcpPrefix) {
+		return true
+	}
+	return false
+}
+
+func validateTrimKMSPrefix(keyURI, prefix string) (string, error) {
+	if !validateKMSPrefix(keyURI, prefix) {
+		return "", fmt.Errorf("key URI must start with %s", prefix)
+	}
+	return strings.TrimPrefix(keyURI, prefix), nil
+}


### PR DESCRIPTION
vendor is missing golang/vendor/github.com/google/tink/go/integration/* which is causing breakages in the GCP script due to a deleted function. I plan on updating the function once this get's working again.

Partial fix to https://github.com/subscriptions-project/encryption/issues/11