### PR TITLE
Fix encryption script

### DIFF
--- a/golang/pkg/encryption/encryption.go
+++ b/golang/pkg/encryption/encryption.go
@@ -195,7 +195,7 @@ func encryptAllSections(parsedHTML *html.Node, encryptedSections []*html.Node, k
 		var content []string
 		for {
 			c := node.FirstChild
-			if (c == nil) {
+			if c == nil {
 				break
 			}
 			content = append(content, renderNode(c))

--- a/golang/pkg/encryption/encryption.go
+++ b/golang/pkg/encryption/encryption.go
@@ -193,7 +193,11 @@ func encryptAllSections(parsedHTML *html.Node, encryptedSections []*html.Node, k
 	}
 	for _, node := range encryptedSections {
 		var content []string
-		for c := node.FirstChild; c != nil; c = c.NextSibling {
+		for {
+			c := node.FirstChild
+			if (c == nil) {
+				break
+			}
 			content = append(content, renderNode(c))
 			node.RemoveChild(c)
 		}

--- a/golang/pkg/encryption/encryption_test.go
+++ b/golang/pkg/encryption/encryption_test.go
@@ -16,7 +16,7 @@ package encryption
 
 import (
 	"github.com/google/tink/go/keyset"
-	tinkpb "github.com/google/tink/proto/tink_go_proto"
+	tinkpb "github.com/google/tink/go/proto/tink_go_proto"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"


### PR DESCRIPTION
Fixes a bug in the encryption script that removes all children of the encrypted text nodes before gathering all of their contents.